### PR TITLE
Sort before interpolating

### DIFF
--- a/rframe/indexes/interpolating_index.py
+++ b/rframe/indexes/interpolating_index.py
@@ -23,6 +23,9 @@ def interpolater(x, xs, ys, kind="linear"):
 @interpolater.register(int)
 def interpolate_number(x, xs, ys, kind="linear"):
     if isinstance(ys[0], (float, int)):
+        sort = np.argsort(xs)
+        xs = np.array(xs)[sort]
+        ys = np.array(ys)[sort]
         return np.interp(x, xs, ys)
     return nn_interpolate(x, xs, ys)
 


### PR DESCRIPTION
In `np.interp` it is presumed that `xs` is sorted. This PR ensures that the `xs` is sorted before apply interpolation.

This solves the randomness issue in https://github.com/XENONnT/fuse/issues/230. Here is the explanation:
  - If in `straxen.URLconfig`, `'&sort=xxxx'` is used, then in the [MongoDB interface of rframe](https://github.com/XENONnT/rframe/blob/06af8ef00142df1468c26348394611c7f403a321/rframe/interfaces/mongo.py#L173-L183), it sends `$sort: xxxx` to MongoDB. However, if `xxxx` is not sufficient enough to determine the order due to duplicated values, the output of MongoDB will be random, meaning that `xxxx` is sorted but within each value of `xxxx` it's random. See the sort consistency section in the [document](https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/).
  - This randomness can finally propagate to the interpolation. For example, if we require `'&sort=xxxx'`, the `time` can be randomly unsorted. But this conflicts with the presumption of `np.interp`, which finally causes randomness of the interpolated output.

------------------------------------

An MWE is
```
import xedocs
import datetime

accessor = xedocs.databases.straxen_db()['pmt_area_to_pes']
datasource = accessor.schema.default_datasource()
labels = {'detector': 'tpc', 'run_id': '046000', 'version': 'v10'}
query = accessor.schema.compile_query(accessor.storage, **labels)
index = query.index.indexes[2]

x = [{'version': 'v10',
      'created_date': datetime.datetime(2023, 10, 24, 15, 40, 47, 945000),
      'comments': '',
      'time': datetime.datetime(2022, 7, 8, 8, 46, 56),
      'detector': 'tpc',
      'pmt': 0,
      'value': 0.0079474222},
     {'version': 'v10',
      'created_date': datetime.datetime(2023, 10, 24, 15, 40, 47, 945000),
      'comments': '',
      'time': datetime.datetime(2022, 7, 19, 15, 48, 16),
      'detector': 'tpc',
      'pmt': 0,
      'value': 0.0079188448}]

y = [{'version': 'v10',
      'created_date': datetime.datetime(2023, 10, 24, 15, 40, 47, 945000),
      'comments': '',
      'time': datetime.datetime(2022, 7, 19, 15, 48, 16),
      'detector': 'tpc',
      'pmt': 0,
      'value': 0.0079188448},
     {'version': 'v10',
      'created_date': datetime.datetime(2023, 10, 24, 15, 40, 47, 945000),
      'comments': '',
      'time': datetime.datetime(2022, 7, 8, 8, 46, 56),
      'detector': 'tpc',
      'pmt': 0,
      'value': 0.0079474222}]

label = datetime.datetime(2022, 7, 16, 7, 18, 14, 927000)

print(index.reduce(x, label)[0]['value'])

print(index.reduce(y, label)[0]['value'])
```
Before the PR it outputs:
```
0.007927332994063166
0.0079474222
```
After the PR it outputs the same values:
```
0.007927332994063166
0.007927332994063166
```


